### PR TITLE
Okx orderbook channel

### DIFF
--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -406,13 +406,11 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 	case "subscribe":
 		e := events.Subscribe{}
 		_ = json.Unmarshal(data, &e)
-		go func() {
-			if c.SubscribeChan != nil {
-				c.SubscribeChan <- &e
-			}
+		if c.SubscribeChan != nil {
+			c.SubscribeChan <- &e
+		}
 
-			c.StructuredEventChan <- e
-		}()
+		c.StructuredEventChan <- e
 
 		return true
 	case "unsubscribe":

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -467,10 +467,12 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 
 		e := events.Success{}
 		_ = json.Unmarshal(data, &e)
-		if c.SuccessChan != nil {
-			c.SuccessChan <- &e
-		}
-		c.StructuredEventChan <- e
+		go func() {
+			if c.SuccessChan != nil {
+				c.SuccessChan <- &e
+			}
+			c.StructuredEventChan <- e
+		}()
 
 		return true
 	}

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -467,12 +467,11 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 
 		e := events.Success{}
 		_ = json.Unmarshal(data, &e)
-		go func() {
-			if c.SuccessChan != nil {
-				c.SuccessChan <- &e
-			}
-			c.StructuredEventChan <- e
-		}()
+
+		if c.SuccessChan != nil {
+			c.SuccessChan <- &e
+		}
+		c.StructuredEventChan <- e
 
 		return true
 	}

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -7,12 +7,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/aiviaio/okex"
-	"github.com/aiviaio/okex/events"
-	"github.com/gorilla/websocket"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/aiviaio/okex"
+	"github.com/aiviaio/okex/events"
+	"github.com/gorilla/websocket"
 )
 
 // ClientWs is the websocket api client
@@ -366,9 +367,7 @@ func (c *ClientWs) receiver(p bool) error {
 					return err
 				}
 
-				go func() {
-					c.process(data, e)
-				}()
+				c.process(data, e)
 			}
 		}
 	}
@@ -468,12 +467,10 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 
 		e := events.Success{}
 		_ = json.Unmarshal(data, &e)
-		go func() {
-			if c.SuccessChan != nil {
-				c.SuccessChan <- &e
-			}
-			c.StructuredEventChan <- e
-		}()
+		if c.SuccessChan != nil {
+			c.SuccessChan <- &e
+		}
+		c.StructuredEventChan <- e
 
 		return true
 	}

--- a/api/ws/public.go
+++ b/api/ws/public.go
@@ -3,11 +3,12 @@ package ws
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/aiviaio/okex"
 	"github.com/aiviaio/okex/events"
 	"github.com/aiviaio/okex/events/public"
 	requests "github.com/aiviaio/okex/requests/ws/public"
-	"strings"
 )
 
 // Public
@@ -559,12 +560,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				if err != nil {
 					return false
 				}
-				go func() {
-					if c.obCh != nil {
-						c.obCh <- &e
-					}
-					c.StructuredEventChan <- e
-				}()
+				if c.obCh != nil {
+					c.obCh <- &e
+				}
+				c.StructuredEventChan <- e
 				return true
 			}
 		}


### PR DESCRIPTION
Problem:
While processing events within `(c *ClientWs) receiver` method, a redundant wrapping in the form of goroutine was used, which caused the Websocket library to allocate additional memory for stack when the goroutine was created, which led to GC not being able to keep up the process of cleaning the memory with the actual rate of stack memory allocation per goroutine via `malg` method.

_When creating a new goroutine the `runtime.malg` function is called. It allocates a stack trace for the newly created goroutine and holds a reference to it until the goroutine finishes execution._

As a result, due to monstrous number of goroutines which keeps growing, goroutines were constantly blocking each other on `send` operation to the channel, making them idling and keeping the allocated memory at heap which can not be cleaned by GC.

Thus, redundant goroutine closures were removed to make the event processing initiated at line:370 with call of `.process()` a blocking operation.
